### PR TITLE
Feature/fav recipe icon nav

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -26,7 +26,7 @@
           <img class="fav-img" id="favImg" src="./favorite-svg.svg">
         </div>
       </header>
-        <article class ="search-container hidden" id="searchContainer">
+        <article class ="search-container" id="searchContainer">
           <div class ="search-header" id="searchHeader">Find a Recipe </div>
           <div class ="search-bar" id="searchBar">
             <form>
@@ -40,7 +40,7 @@
             <input class = "name-search" type = "radio" name = "searchMode" value = "name">Search by Name</input>
           </div>
         </article>
-      <section class ="main-page-container hidden" id="mainPageContainer">
+      <section class ="main-page-container" id="mainPageContainer">
         <div class ="feature-container" id="featureContainer">
           <div class="feature-image-box" id="featureImageBox">
             <img class="random-feature-img" src="">
@@ -99,7 +99,7 @@
             <p class ="recipe-info-box" id="recipeBox"></p>
           </article>
       </section>
-        <article class ="search-favorite-container" id="searchFavoriteContainer">
+        <article class ="search-favorite-container hidden" id="searchFavoriteContainer">
             <div class ="search-favorite-header" id="searchHeader">Search Favorites</div>
             <div class ="search-favorite-bar" id="searchFavoriteBar">
             <form>
@@ -113,12 +113,12 @@
             <input class = "name-search-favorite" type = "radio" name = "searchMode" value = "name">Search by Name</input>
           </div>
         </article>
-        <section class ="main-favorite-container" id="mainFavoriteContainer">
+        <section class ="main-favorite-container hidden" id="mainFavoriteContainer">
           <section class="favorite-recipe-container" id="favoriteRecipeContainer">
             <div class="favorite-recipe-title-wrapper"> 
               <p class="favorite-recipe-title">Favorite Recipes</p>
             </div>
-            <div class ="favorite-recipe-icon" id="favoriteRecipeIcon">Recipe Icon</div>
+            <div class ="favorite-recipe-icon hidden" id="favoriteRecipeIcon">Recipe Icon</div>
           </section>
         <section class="user-info-pantry-container" id="userInfoPantryContainer">
           <div class="user-pantry-title-wrapper"> 

--- a/dist/index.html
+++ b/dist/index.html
@@ -118,7 +118,7 @@
             <div class="favorite-recipe-title-wrapper"> 
               <p class="favorite-recipe-title">Favorite Recipes</p>
             </div>
-            <div class ="favorite-recipe-icon hidden" id="favoriteRecipeIcon">Recipe Icon</div>
+            <div class ="favorite-recipe-icon hidden" id="favoriteRecipeIcon"></div>
           </section>
         <section class="user-info-pantry-container" id="userInfoPantryContainer">
           <div class="user-pantry-title-wrapper"> 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -55,6 +55,7 @@ window.addEventListener('load', loadNewUser);
 window.addEventListener('load', displayAllNames);
 recipeSidebarList.addEventListener('click', viewRecipe);
 recipeIconContainer.addEventListener('click', viewRecipeFromIcon);
+favoriteRecipeContainer.addEventListener('click', viewRecipeFromFavIcon);
 homeButton.addEventListener('click', showHomePage);
 searchButton.addEventListener('click', filterRecipe);
 favoriteSearchButton.addEventListener('click', filterFavoriteRecipes)
@@ -171,6 +172,23 @@ function viewRecipeFromIcon(event){
   displaySelectedRecipeImg();
 }
 
+function viewRecipeFromFavIcon(event){
+  selectedRecipeIcon = event.target.src
+  console.log(selectedRecipeIcon)
+  selectedRecipe = allRecipes.filter(recipe => selectedRecipeIcon === recipe.image)[0];
+  hide(homePage);
+  hide(searchContainer);
+  hide(favoritesPage);
+  hide(searchFavoritesContainer);
+  show(recipePage);
+  displaySelectedRecipeName();
+  displayRecipeInstructions();
+  displayIngredientNames();
+  displayIngredientCosts();
+  displayIngredientQuantities();
+  displayTotalCostOfAllIngredients();
+  displaySelectedRecipeImg();
+}
 
 
 function displaySelectedRecipeName() {

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -22,6 +22,7 @@ const favoritePageButton = document.querySelector('.fav-img');
 const searchButton = document.querySelector('.search-button');
 const favoriteSearchButton = document.querySelector('.favorite-search-button')
 const recipeSidebarList = document.querySelector('.list-recipes');
+const recipeIconContainer = document.querySelector('.recipe-icon-container');
 const icon1Img = document.querySelector('.icon-1-img');
 const icon2Img = document.querySelector('.icon-2-img');
 const icon3Img = document.querySelector('.icon-3-img');
@@ -53,6 +54,7 @@ window.addEventListener('load', updateMainPageFeatureImg);
 window.addEventListener('load', loadNewUser);
 window.addEventListener('load', displayAllNames);
 recipeSidebarList.addEventListener('click', viewRecipe);
+recipeIconContainer.addEventListener('click', viewRecipeFromIcon);
 homeButton.addEventListener('click', showHomePage);
 searchButton.addEventListener('click', filterRecipe);
 favoriteSearchButton.addEventListener('click', filterFavoriteRecipes)
@@ -69,6 +71,7 @@ const allRecipes = recipeData.recipeData.map(recipe => new Recipe(recipe, ingred
 const recipeRepository =  new RecipeRepository(allRecipes);
 let user;
 let selectedRecipeName;
+let selectedRecipeIcon;
 let selectedRecipe;
 
 // ***** Functions ***** //
@@ -133,7 +136,8 @@ function showFavoritesPage() {
 }
 
 function viewRecipe(event) {
-  selectedRecipeName = event.target.innerText;
+  selectedRecipeName = event.target.innerText
+  console.log(selectedRecipeName)
   selectedRecipe = allRecipes.filter(recipe => selectedRecipeName === recipe.name)[0];
   hide(homePage);
   hide(searchContainer);
@@ -148,6 +152,26 @@ function viewRecipe(event) {
   displayTotalCostOfAllIngredients();
   displaySelectedRecipeImg();
 }
+
+function viewRecipeFromIcon(event){
+  selectedRecipeIcon = event.target.src
+  console.log(selectedRecipeIcon)
+  selectedRecipe = allRecipes.filter(recipe => selectedRecipeIcon === recipe.image)[0];
+  hide(homePage);
+  hide(searchContainer);
+  hide(favoritesPage);
+  hide(searchFavoritesContainer);
+  show(recipePage);
+  displaySelectedRecipeName();
+  displayRecipeInstructions();
+  displayIngredientNames();
+  displayIngredientCosts();
+  displayIngredientQuantities();
+  displayTotalCostOfAllIngredients();
+  displaySelectedRecipeImg();
+}
+
+
 
 function displaySelectedRecipeName() {
   recipeNameBox.innerText = selectedRecipe.name;
@@ -245,6 +269,7 @@ function filterFavoriteRecipesByName(name) {
 }
 
 function showFavoriteRecipeImages(){
+  show(favoriteRecipeImages);
   favoriteRecipeImages.innerHTML = '';
   user.recipesToCook.forEach(recipe => {
   favoriteRecipeImages.innerHTML += `<section class = "favorite-recipe-icon" >

--- a/src/styles.css
+++ b/src/styles.css
@@ -494,11 +494,11 @@ filter: drop-shadow(5px 10px 3px black);
       display: flex;
       height: 125px;
       width: 125px;
-      filter: drop-shadow(5px 6px 3px grey);
-      border: 1px solid grey;
       border-radius: 8px;
       margin-left: 1;
       cursor: pointer;
+      font-family: 'Edu TAS Beginner';
+      font-size: 25pt;
     }
 
       .favorite-recipe-title,


### PR DESCRIPTION
**What’s this PR do?**

- From user story favorite page the user is able to click on the favorite recipe icon and be directed to the user story view recipe page

**How should this be manually tested?**

-  pull down PR and input npm start in terminal and open http://http://localhost:8080/ in browser
How should this be manually tested?

**Where should the reviewer start?**
- Click on a recipe on the side bar or recipe icon on main page
- Save a recipe as a favorite
- click the fav icon on the right side of header bar (heart image) to go to the favorites page and view fav recipes
- click on the icon to view the recipe information

**Any background context you want to provide?**

- Needs refactor to dry up code

Screenshots (if appropriate)
![2022-07-17 18 43 51](https://user-images.githubusercontent.com/102189342/179431688-2d93267f-03a6-4126-9ab1-4973c8ccb09d.gif)

